### PR TITLE
Make id can be null in `StandardUriDesign`, when query single resource without knowing id

### DIFF
--- a/lib/src/routing/standard_uri_design.dart
+++ b/lib/src/routing/standard_uri_design.dart
@@ -38,23 +38,23 @@ class StandardUriDesign implements UriDesign {
   /// Returns a URL for the primary resource of type [type] with id [id].
   /// E.g. `/books/123`.
   @override
-  Uri resource(String type, String id) => _resolve([type, id]);
+  Uri resource(String type, String? id) => _resolve([type, if (id != null) id]);
 
   /// Returns a URL for the relationship itself.
   /// The [type] and [id] identify the primary resource and the [relationship]
   /// is the relationship name.
   /// E.g. `/books/123/relationships/authors`.
   @override
-  Uri relationship(String type, String id, String relationship) =>
-      _resolve([type, id, 'relationships', relationship]);
+  Uri relationship(String type, String? id, String relationship) =>
+      _resolve([type, if (id != null) id, 'relationships', relationship]);
 
   /// Returns a URL for the related resource or collection.
   /// The [type] and [id] identify the primary resource and the [relationship]
   /// is the relationship name.
   /// E.g. `/books/123/authors`.
   @override
-  Uri related(String type, String id, String relationship) =>
-      _resolve([type, id, relationship]);
+  Uri related(String type, String? id, String relationship) =>
+      _resolve([type, if (id != null) id, relationship]);
 
   Uri _resolve(List<String> pathSegments) =>
       base.resolveUri(Uri(pathSegments: pathSegments));

--- a/test/unit/routing/url_test.dart
+++ b/test/unit/routing/url_test.dart
@@ -9,6 +9,11 @@ void main() {
     expect(url.related('books', '42', 'author').toString(), '/books/42/author');
     expect(url.relationship('books', '42', 'author').toString(),
         '/books/42/relationships/author');
+
+    expect(url.resource('me', null).toString(), '/me');
+    expect(url.related('me', null, 'books').toString(), '/me/books');
+    expect(url.relationship('me', null, 'books').toString(),
+        '/me/relationships/books');
   });
 
   test('Authority is retained if exists in base', () {
@@ -20,6 +25,11 @@ void main() {
         'https://example.com/books/42/author');
     expect(url.relationship('books', '42', 'author').toString(),
         'https://example.com/books/42/relationships/author');
+
+    expect(url.resource('me', null).toString(), 'https://example.com/me');
+    expect(url.related('me', null, 'books').toString(), 'https://example.com/me/books');
+    expect(url.relationship('me', null, 'books').toString(),
+        'https://example.com/me/relationships/books');
   });
 
   test('Authority and path is retained if exists in base (directory path)', () {
@@ -31,5 +41,10 @@ void main() {
         'https://example.com/foo/books/42/author');
     expect(url.relationship('books', '42', 'author').toString(),
         'https://example.com/foo/books/42/relationships/author');
+
+    expect(url.resource('me', null).toString(), 'https://example.com/foo/me');
+    expect(url.related('me', null, 'books').toString(), 'https://example.com/foo/me/books');
+    expect(url.relationship('me', null, 'books').toString(),
+        'https://example.com/foo/me/relationships/books');
   });
 }


### PR DESCRIPTION
I encountered a situation that query single resource, but not knowing id, such as
```
GET /me
GET /me/relationships/books
GET /me/family
...etc
```

So I make id to can be nullable, but I can't find the jsonapi spec in those situation, if there is would be better!