### PR TITLE
Add missing handlers

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -24,6 +24,8 @@
 library client;
 
 export 'package:json_api/src/client/client.dart';
+export 'package:json_api/src/client/disposable_handler.dart';
+export 'package:json_api/src/client/persistent_handler.dart';
 export 'package:json_api/src/client/request.dart';
 export 'package:json_api/src/client/response/collection_fetched.dart';
 export 'package:json_api/src/client/response/related_resource_fetched.dart';


### PR DESCRIPTION
Add missing handlers in export file: `DisposableHandler` & `PersistentHandler` 