### PR TITLE
Add include parameters to create and update methods of the routing client

### DIFF
--- a/lib/src/client/routing_client.dart
+++ b/lib/src/client/routing_client.dart
@@ -59,6 +59,7 @@ class RoutingClient {
     Map<String, Object?> meta = const {},
     Map<String, Object?> documentMeta = const {},
     Map<String, String> headers = const {},
+    Iterable<String> include = const [],
   }) async {
     final response = await send(
         baseUri.collection(type),
@@ -70,7 +71,8 @@ class RoutingClient {
           })
           ..meta.addAll(meta))
           ..meta.addAll(documentMeta))
-          ..headers.addAll(headers));
+          ..headers.addAll(headers)
+          ..include(include));
 
     return ResourceCreated(
         response.http, response.document ?? (throw FormatException()));
@@ -254,6 +256,7 @@ class RoutingClient {
     Map<String, Object?> meta = const {},
     Map<String, Object?> documentMeta = const {},
     Map<String, String> headers = const {},
+    Iterable<String> include = const [],
   }) async {
     final response = await send(
         baseUri.resource(type, id),
@@ -265,7 +268,8 @@ class RoutingClient {
           })
           ..meta.addAll(meta))
           ..meta.addAll(documentMeta))
-          ..headers.addAll(headers));
+          ..headers.addAll(headers)
+          ..include(include));
     return ResourceUpdated(response.http, response.document);
   }
 
@@ -279,6 +283,7 @@ class RoutingClient {
     Map<String, Object?> meta = const {},
     Map<String, Object?> documentMeta = const {},
     Map<String, String> headers = const {},
+    Iterable<String> include = const [],
   }) async {
     final response = await send(
         baseUri.collection(type),
@@ -290,7 +295,8 @@ class RoutingClient {
           })
           ..meta.addAll(meta))
           ..meta.addAll(documentMeta))
-          ..headers.addAll(headers));
+          ..headers.addAll(headers)
+          ..include(include));
     return ResourceUpdated(response.http, response.document);
   }
 


### PR DESCRIPTION
This PR adds include parameters to createNew, create and updateResource methods of the RoutingClient. This allows to see related resources of the newly created or updated resources. 

[According to the specification](https://jsonapi.org/format/#fetching-includes), there should be an option to include additional resources not only when fetching but also when updating or creating resources:
> Note: This section applies to any endpoint that responds with primary data, regardless of the request type. For instance, a server could support the inclusion of related resources along with a POST request to create a resource or relationship.