### PR TITLE
Support for nested filters

### DIFF
--- a/lib/src/client/request.dart
+++ b/lib/src/client/request.dart
@@ -56,7 +56,7 @@ class Request with HttpHeaders {
 
   /// Response filtering.
   /// https://jsonapi.org/format/#fetching-filtering
-  void filter(Map<String, dynamic> filter) {
+  void filter(Map<String, Object> filter) {
     query.addAll(Filter(filter).asQueryParameters);
   }
 }

--- a/lib/src/client/request.dart
+++ b/lib/src/client/request.dart
@@ -56,7 +56,7 @@ class Request with HttpHeaders {
 
   /// Response filtering.
   /// https://jsonapi.org/format/#fetching-filtering
-  void filter(Map<String, String> filter) {
+  void filter(Map<String, dynamic> filter) {
     query.addAll(Filter(filter).asQueryParameters);
   }
 }

--- a/lib/src/client/routing_client.dart
+++ b/lib/src/client/routing_client.dart
@@ -113,7 +113,7 @@ class RoutingClient {
     Map<String, String> headers = const {},
     Map<String, String> query = const {},
     Map<String, String> page = const {},
-    Map<String, String> filter = const {},
+    Map<String, dynamic> filter = const {},
     Iterable<String> include = const [],
     Iterable<String> sort = const [],
     Map<String, Iterable<String>> fields = const {},
@@ -149,7 +149,7 @@ class RoutingClient {
     String relationship, {
     Map<String, String> headers = const {},
     Map<String, String> page = const {},
-    Map<String, String> filter = const {},
+    Map<String, dynamic> filter = const {},
     Iterable<String> include = const [],
     Iterable<String> sort = const [],
     Map<String, Iterable<String>> fields = const {},
@@ -207,7 +207,7 @@ class RoutingClient {
     String relationship, {
     Map<String, String> headers = const {},
     Map<String, String> query = const {},
-    Map<String, String> filter = const {},
+    Map<String, dynamic> filter = const {},
     Iterable<String> include = const [],
     Map<String, Iterable<String>> fields = const {},
   }) async {
@@ -227,7 +227,7 @@ class RoutingClient {
     String type,
     String id, {
     Map<String, String> headers = const {},
-    Map<String, String> filter = const {},
+    Map<String, dynamic> filter = const {},
     Iterable<String> include = const [],
     Map<String, Iterable<String>> fields = const {},
     Map<String, String> query = const {},

--- a/lib/src/client/routing_client.dart
+++ b/lib/src/client/routing_client.dart
@@ -113,7 +113,7 @@ class RoutingClient {
     Map<String, String> headers = const {},
     Map<String, String> query = const {},
     Map<String, String> page = const {},
-    Map<String, dynamic> filter = const {},
+    Map<String, Object> filter = const {},
     Iterable<String> include = const [],
     Iterable<String> sort = const [],
     Map<String, Iterable<String>> fields = const {},
@@ -149,7 +149,7 @@ class RoutingClient {
     String relationship, {
     Map<String, String> headers = const {},
     Map<String, String> page = const {},
-    Map<String, dynamic> filter = const {},
+    Map<String, Object> filter = const {},
     Iterable<String> include = const [],
     Iterable<String> sort = const [],
     Map<String, Iterable<String>> fields = const {},
@@ -207,7 +207,7 @@ class RoutingClient {
     String relationship, {
     Map<String, String> headers = const {},
     Map<String, String> query = const {},
-    Map<String, dynamic> filter = const {},
+    Map<String, Object> filter = const {},
     Iterable<String> include = const [],
     Map<String, Iterable<String>> fields = const {},
   }) async {
@@ -227,7 +227,7 @@ class RoutingClient {
     String type,
     String id, {
     Map<String, String> headers = const {},
-    Map<String, dynamic> filter = const {},
+    Map<String, Object> filter = const {},
     Iterable<String> include = const [],
     Map<String, Iterable<String>> fields = const {},
     Map<String, String> query = const {},

--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -14,7 +14,7 @@ class Filter with MapMixin<String, Object> {
   }
 
   static Filter fromUri(Uri uri) {
-    Map<String, Object> filters = {};
+    final filters = <String, Object>{};
     uri.queryParametersAll.forEach((key, value) {
       if (_validationRegex.hasMatch(key)) {
         final matches = _extractionRegex.allMatches(key).toList();
@@ -30,21 +30,22 @@ class Filter with MapMixin<String, Object> {
     String value,
   ) {
     final key = matches[0].group(1) ?? '';
-    if (key.isNotEmpty) {
-      if (matches.length == 1) {
-        destination[key] = value;
-        return;
-      }
-      if (!destination.containsKey(key) ||
-          destination[key] is! Map<String, Object>) {
-        destination[key] = <String, Object>{};
-      }
-      _convertToMapAndMerge(
-        matches.sublist(1),
-        destination[key] as Map<String, Object>,
-        value,
-      );
+    if (key.isEmpty) {
+      return;
     }
+    if (matches.length == 1) {
+      destination[key] = value;
+      return;
+    }
+    if (!destination.containsKey(key) ||
+        destination[key] is! Map<String, Object>) {
+      destination[key] = <String, Object>{};
+    }
+    _convertToMapAndMerge(
+      matches.sublist(1),
+      destination[key] as Map<String, Object>,
+      value,
+    );
   }
 
   static final _validationRegex = RegExp(r'^filter(?:\[[^\[\]]+\])+$');
@@ -64,6 +65,11 @@ class Filter with MapMixin<String, Object> {
         queryParameters[keyWithPrefix] = value;
       } else if (value is Map<String, Object>) {
         queryParameters.addAll(_flattenFiltersMap(value, keyWithPrefix));
+      } else {
+        throw ArgumentError(
+          'Filter values must have a type of String or Map<String, Object>',
+          'value',
+        );
       }
     });
     return queryParameters;
@@ -76,7 +82,7 @@ class Filter with MapMixin<String, Object> {
   void operator []=(String key, Object value) {
     if (value is! String && value is! Map<String, Object>) {
       throw ArgumentError(
-        'Filter value must have a type of String or Map<String, Object>',
+        'Filter values must have a type of String or Map<String, Object>',
         'value',
       );
     }

--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -1,35 +1,82 @@
 import 'dart:collection';
 
-class Filter with MapMixin<String, String> {
+class Filter with MapMixin<String, dynamic> {
   /// Example:
   /// ```dart
-  /// Filter({'post': '1,2', 'author': '12'}).addTo(url);
+  /// Filter({'post': '1,2', 'author': {'id': '12', 'role': 'admin'}}).addTo(url);
   /// ```
   /// encodes into
   /// ```
-  /// ?filter[post]=1,2&filter[author]=12
+  /// ?filter[post]=1,2&filter[author][id]=12&filter[author][role]=admin
   /// ```
-  Filter([Map<String, String> parameters = const {}]) {
+  Filter([Map<String, dynamic> parameters = const {}]) {
     addAll(parameters);
   }
 
-  static Filter fromUri(Uri uri) => Filter(uri.queryParametersAll
-      .map((k, v) => MapEntry(_regex.firstMatch(k)?.group(1) ?? '', v.last))
-    ..removeWhere((k, v) => k.isEmpty));
+  static Filter fromUri(Uri uri) {
+    Map<String, dynamic> filters = {};
+    uri.queryParametersAll.forEach((key, value) {
+      if (_validationRegex.hasMatch(key)) {
+        final matches = _extractionRegex.allMatches(key).toList();
+        _convertToMapAndMerge(matches, filters, value.last);
+      }
+    });
+    return Filter(filters);
+  }
 
-  static final _regex = RegExp(r'^filter\[(.+)\]$');
+  static void _convertToMapAndMerge(
+    List<RegExpMatch> matches,
+    Map<String, dynamic> destination,
+    String value,
+  ) {
+    final key = matches[0].group(1) ?? '';
+    if (key.isNotEmpty) {
+      if (matches.length == 1) {
+        destination[key] = value;
+        return;
+      }
+      if (!destination.containsKey(key)) {
+        destination[key] = <String, dynamic>{};
+      }
+      _convertToMapAndMerge(matches.sublist(1), destination[key], value);
+    }
+  }
 
-  final _ = <String, String>{};
+  static final _validationRegex = RegExp(r'^filter(?:\[[^\[\]]+\])+$');
+  static final _extractionRegex = RegExp(r'\[([^\[\]]+)\]');
+
+  final _ = <String, dynamic>{};
 
   /// Converts to a map of query parameters
-  Map<String, String> get asQueryParameters =>
-      _.map((k, v) => MapEntry('filter[$k]', v));
+  Map<String, String> get asQueryParameters => _flattenFiltersMap(_);
+
+  Map<String, String> _flattenFiltersMap(Map<String, dynamic> filters,
+      [String keyPrefix = 'filter']) {
+    final queryParameters = <String, String>{};
+    filters.forEach((key, value) {
+      final keyWithPrefix = '$keyPrefix[$key]';
+      if (value is String) {
+        queryParameters[keyWithPrefix] = value;
+      } else if (value is Map<String, dynamic>) {
+        queryParameters.addAll(_flattenFiltersMap(value, keyWithPrefix));
+      }
+    });
+    return queryParameters;
+  }
 
   @override
-  String? operator [](Object? key) => _[key];
+  dynamic operator [](Object? key) => _[key];
 
   @override
-  void operator []=(String key, String value) => _[key] = value;
+  void operator []=(String key, dynamic value) {
+    if (value is! String && value is! Map<String, dynamic>) {
+      throw ArgumentError(
+        'Filter value must have a type of String or Map<String, dynamic>',
+        'value',
+      );
+    }
+    _[key] = value;
+  }
 
   @override
   void clear() => _.clear();

--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-class Filter with MapMixin<String, dynamic> {
+class Filter with MapMixin<String, Object> {
   /// Example:
   /// ```dart
   /// Filter({'post': '1,2', 'author': {'id': '12', 'role': 'admin'}}).addTo(url);
@@ -9,12 +9,12 @@ class Filter with MapMixin<String, dynamic> {
   /// ```
   /// ?filter[post]=1,2&filter[author][id]=12&filter[author][role]=admin
   /// ```
-  Filter([Map<String, dynamic> parameters = const {}]) {
+  Filter([Map<String, Object> parameters = const {}]) {
     addAll(parameters);
   }
 
   static Filter fromUri(Uri uri) {
-    Map<String, dynamic> filters = {};
+    Map<String, Object> filters = {};
     uri.queryParametersAll.forEach((key, value) {
       if (_validationRegex.hasMatch(key)) {
         final matches = _extractionRegex.allMatches(key).toList();
@@ -26,7 +26,7 @@ class Filter with MapMixin<String, dynamic> {
 
   static void _convertToMapAndMerge(
     List<RegExpMatch> matches,
-    Map<String, dynamic> destination,
+    Map<String, Object> destination,
     String value,
   ) {
     final key = matches[0].group(1) ?? '';
@@ -35,29 +35,34 @@ class Filter with MapMixin<String, dynamic> {
         destination[key] = value;
         return;
       }
-      if (!destination.containsKey(key)) {
-        destination[key] = <String, dynamic>{};
+      if (!destination.containsKey(key) ||
+          destination[key] is! Map<String, Object>) {
+        destination[key] = <String, Object>{};
       }
-      _convertToMapAndMerge(matches.sublist(1), destination[key], value);
+      _convertToMapAndMerge(
+        matches.sublist(1),
+        destination[key] as Map<String, Object>,
+        value,
+      );
     }
   }
 
   static final _validationRegex = RegExp(r'^filter(?:\[[^\[\]]+\])+$');
   static final _extractionRegex = RegExp(r'\[([^\[\]]+)\]');
 
-  final _ = <String, dynamic>{};
+  final _ = <String, Object>{};
 
   /// Converts to a map of query parameters
   Map<String, String> get asQueryParameters => _flattenFiltersMap(_);
 
-  Map<String, String> _flattenFiltersMap(Map<String, dynamic> filters,
+  Map<String, String> _flattenFiltersMap(Map<String, Object> filters,
       [String keyPrefix = 'filter']) {
     final queryParameters = <String, String>{};
     filters.forEach((key, value) {
       final keyWithPrefix = '$keyPrefix[$key]';
       if (value is String) {
         queryParameters[keyWithPrefix] = value;
-      } else if (value is Map<String, dynamic>) {
+      } else if (value is Map<String, Object>) {
         queryParameters.addAll(_flattenFiltersMap(value, keyWithPrefix));
       }
     });
@@ -68,10 +73,10 @@ class Filter with MapMixin<String, dynamic> {
   dynamic operator [](Object? key) => _[key];
 
   @override
-  void operator []=(String key, dynamic value) {
-    if (value is! String && value is! Map<String, dynamic>) {
+  void operator []=(String key, Object value) {
+    if (value is! String && value is! Map<String, Object>) {
       throw ArgumentError(
-        'Filter value must have a type of String or Map<String, dynamic>',
+        'Filter value must have a type of String or Map<String, Object>',
         'value',
       );
     }
@@ -85,5 +90,5 @@ class Filter with MapMixin<String, dynamic> {
   Iterable<String> get keys => _.keys;
 
   @override
-  String? remove(Object? key) => _.remove(key);
+  Object? remove(Object? key) => _.remove(key);
 }

--- a/lib/src/query/filter.dart
+++ b/lib/src/query/filter.dart
@@ -70,7 +70,7 @@ class Filter with MapMixin<String, Object> {
   }
 
   @override
-  dynamic operator [](Object? key) => _[key];
+  Object? operator [](Object? key) => _[key];
 
   @override
   void operator []=(String key, Object value) {

--- a/test/unit/query/filter_test.dart
+++ b/test/unit/query/filter_test.dart
@@ -14,8 +14,10 @@ void main() {
       final f = Filter();
       f['foo'] = 'bar';
       f['bar'] = 'foo';
+      f['foobar'] = {'foo': 'bar'};
       expect(f['foo'], 'bar');
       expect(f['bar'], 'foo');
+      expect(f['foobar'], {'foo': 'bar'});
       f.remove('foo');
       expect(f['foo'], isNull);
       f.clear();
@@ -23,15 +25,20 @@ void main() {
     });
 
     test('Can decode url', () {
-      final uri = Uri.parse('/articles?filter[post]=1,2&filter[author]=12');
+      final uri = Uri.parse('/articles?filter[post]=1,2&filter[author][id]=12');
       final filter = Filter.fromUri(uri);
       expect(filter['post'], '1,2');
-      expect(filter['author'], '12');
+      expect(filter['author'], {'id': '12'});
     });
 
     test('Can convert to query parameters', () {
-      expect(Filter({'post': '1,2', 'author': '12'}).asQueryParameters,
-          {'filter[post]': '1,2', 'filter[author]': '12'});
+      expect(
+        Filter({
+          'post': '1,2',
+          'author': {'id': '12'}
+        }).asQueryParameters,
+        {'filter[post]': '1,2', 'filter[author][id]': '12'},
+      );
     });
   });
 }


### PR DESCRIPTION
This PR adds support for nested filter parameters.

Sample usecases:
- Retrieving shared posts based on original post's author id: `filter[parent][author][id]=23461`
- Ranges: `filter[price][min]=10&filter[price][max]=20`